### PR TITLE
Step3. 특강 정보를 가져오는 api 구현

### DIFF
--- a/src/main/kotlin/com/yuiyeong/lectureenroll/controller/LectureSessionController.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/controller/LectureSessionController.kt
@@ -2,8 +2,10 @@ package com.yuiyeong.lectureenroll.controller
 
 import com.yuiyeong.lectureenroll.controller.dto.ApplicationRequest
 import com.yuiyeong.lectureenroll.controller.dto.LectureSessionDto
+import com.yuiyeong.lectureenroll.controller.dto.ListResult
 import com.yuiyeong.lectureenroll.controller.dto.Result
 import com.yuiyeong.lectureenroll.service.LectureSessionService
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -15,6 +17,14 @@ import org.springframework.web.bind.annotation.RestController
 class LectureSessionController(
     private val lectureSessionService: LectureSessionService
 ) {
+
+    @GetMapping
+    fun list(): ListResult<LectureSessionDto> {
+        return ListResult(
+            lectureSessionService.findAll().map { LectureSessionDto.from(it) }
+        )
+    }
+
     @PostMapping("{sessionId}/apply")
     fun enroll(
         @PathVariable("sessionId") sessionId: Long,

--- a/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionJpaRepository.kt
@@ -1,6 +1,10 @@
 package com.yuiyeong.lectureenroll.infra
 
 import com.yuiyeong.lectureenroll.infra.entity.LectureSessionEntity
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface LectureSessionJpaRepository : JpaRepository<LectureSessionEntity, Long>
+interface LectureSessionJpaRepository : JpaRepository<LectureSessionEntity, Long> {
+    @EntityGraph(attributePaths = ["lecture"])
+    override fun findAll(): MutableList<LectureSessionEntity>
+}

--- a/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionRepositoryImpl.kt
@@ -13,6 +13,8 @@ class LectureSessionRepositoryImpl(
     override fun findOneById(id: Long): LectureSession? =
         jpaRepository.findById(id).map { it.toLectureSession() }.orElse(null)
 
+    override fun findAll(): List<LectureSession> = jpaRepository.findAll().map { it.toLectureSession() }
+
     override fun save(lectureSession: LectureSession): LectureSession =
         jpaRepository.save(lectureSession.toEntity()).toLectureSession()
 

--- a/src/main/kotlin/com/yuiyeong/lectureenroll/repository/LectureSessionRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/repository/LectureSessionRepository.kt
@@ -6,6 +6,8 @@ interface LectureSessionRepository {
 
     fun findOneById(id: Long): LectureSession?
 
+    fun findAll(): List<LectureSession>
+
     fun save(lectureSession: LectureSession): LectureSession
 
     fun deleteAll()

--- a/src/main/kotlin/com/yuiyeong/lectureenroll/service/LectureSessionService.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/service/LectureSessionService.kt
@@ -15,6 +15,10 @@ class LectureSessionService(
     private val sessionRepository: LectureSessionRepository,
     private val enrollmentRepository: EnrollmentRepository,
 ) {
+    fun findAll(): List<LectureSession> {
+        return sessionRepository.findAll()
+    }
+
     fun enroll(lectureSessionId: Long, studentId: Long): LectureSession {
         val session = sessionRepository.findOneById(lectureSessionId) ?: throw LectureSessionNotFoundException()
         val student = studentRepository.findOneById(studentId) ?: throw StudentNotFoundException()

--- a/src/test/kotlin/com/yuiyeong/lectureenroll/repository/LectureSessionRepositoryTest.kt
+++ b/src/test/kotlin/com/yuiyeong/lectureenroll/repository/LectureSessionRepositoryTest.kt
@@ -54,4 +54,32 @@ class LectureSessionRepositoryTest @Autowired constructor(
         Assertions.assertThat(foundOne.enrollmentPeriod).isEqualTo(savedOne.enrollmentPeriod)
         Assertions.assertThat(foundOne.lecturePeriod).isEqualTo(savedOne.lecturePeriod)
     }
+
+    /**
+     * 모든 lectureSession 을 lecture 정보와 함께 가져와야 한다.
+     */
+    @Test
+    fun `should return all lecture sessions with the lecture`() {
+        // given
+        val sessionSize = 5
+        (0..<sessionSize).forEach {
+            val delta = it.toLong()
+            val lectureSession = createLectureSession(
+                lecture,
+                LocalDateTime.now().minusDays(1 + delta),
+                LocalDateTime.now().plusWeeks(1 + delta),
+                id = 0L
+            )
+            lectureSessionRepository.save(lectureSession)
+        }
+
+        // when
+        val lectureSessions = lectureSessionRepository.findAll()
+
+        // then
+        Assertions.assertThat(lectureSessions.count()).isEqualTo(sessionSize)
+        lectureSessions.forEach {
+            Assertions.assertThat(it.lecture.id).isEqualTo(lecture.id)
+        }
+    }
 }

--- a/src/test/kotlin/com/yuiyeong/lectureenroll/service/LectureSessionServiceTest.kt
+++ b/src/test/kotlin/com/yuiyeong/lectureenroll/service/LectureSessionServiceTest.kt
@@ -42,7 +42,6 @@ class LectureSessionServiceTest @Autowired constructor(
         reset(enrollmentRepository)
     }
 
-
     @Nested
     inner class EnrollmentTest {
 


### PR DESCRIPTION
- GET /lecture-sessions
- 구현 로직
    - LectureSessionJpaRepository 에서 findAll 을 override 하여, lecture 정보를 fetch join 할 수 있게하였습니다.
    - LectureSessionService 에서는 repository 에 위임 하도록 하였습니다. 
- 리뷰 포인트
    -  LectureSessionJpaRepository 부분 리뷰 부탁드립니다.