### PR TITLE
Step4. 비관적 락 사용해서 동시성 대응

### DIFF
--- a/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionJpaRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionJpaRepository.kt
@@ -1,12 +1,21 @@
 package com.yuiyeong.lectureenroll.infra
 
 import com.yuiyeong.lectureenroll.infra.entity.LectureSessionEntity
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.QueryHints
+import org.springframework.data.repository.query.Param
 
 interface LectureSessionJpaRepository : JpaRepository<LectureSessionEntity, Long> {
     @EntityGraph(attributePaths = ["lecture"])
     override fun findAll(): MutableList<LectureSessionEntity>
 
     fun findAllByLectureId(lectureId: Long): List<LectureSessionEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    fun findOneWithLockById(@Param("id") id: Long): LectureSessionEntity?
 }

--- a/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionRepositoryImpl.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/infra/LectureSessionRepositoryImpl.kt
@@ -13,6 +13,8 @@ class LectureSessionRepositoryImpl(
     override fun findOneById(id: Long): LectureSession? =
         jpaRepository.findById(id).map { it.toLectureSession() }.orElse(null)
 
+    override fun findOneWithLockById(id: Long): LectureSession? = jpaRepository.findOneWithLockById(id)?.toLectureSession()
+
     override fun findAll(): List<LectureSession> = jpaRepository.findAll().map { it.toLectureSession() }
 
     override fun findAllByLectureId(lectureId: Long): List<LectureSession> =

--- a/src/main/kotlin/com/yuiyeong/lectureenroll/repository/LectureSessionRepository.kt
+++ b/src/main/kotlin/com/yuiyeong/lectureenroll/repository/LectureSessionRepository.kt
@@ -5,6 +5,8 @@ import com.yuiyeong.lectureenroll.domain.LectureSession
 interface LectureSessionRepository {
     fun findOneById(id: Long): LectureSession?
 
+    fun findOneWithLockById(id: Long): LectureSession?
+
     fun findAll(): List<LectureSession>
 
     fun findAllByLectureId(lectureId: Long): List<LectureSession>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,10 @@ spring:
         hibernate:
             ddl-auto: create
         properties:
+            jakarta.persistence.lock.timeout: 10000  # 10초
             hibernate:
                 show_sql: true
+                lock.timeout: 10000  # 10초
 logging:
     level:
         org.hibernate.SQL: debug


### PR DESCRIPTION
- JPA `@Lock` 애노테이션을 사용하여, 비관적 락을 획득하도록 했습니다.
- 격리 수준은 READ_COMMITED 를 사용하도록 했습니다.
- 리뷰 포인트
    - LectureSession::enroll 에서 lock 을 획득하여, 수강 신청을 진행하고 있는데 이 부분 리뷰 부탁드립니다.
    - test case 에 대한 리뷰 부탁드립니다.